### PR TITLE
[#10031] Fix issue "counsle-gtags command doesn't work in c-c++ layer"

### DIFF
--- a/layers/+tags/gtags/funcs.el
+++ b/layers/+tags/gtags/funcs.el
@@ -47,8 +47,8 @@ Otherwise does nothing."
       "gG" 'helm-gtags-dwim-other-window
       "gi" 'helm-gtags-tags-in-this-function
       "gl" 'helm-gtags-parse-file
-      "gn" 'helm-gtags-next-history
-      "gp" 'helm-gtags-previous-history
+      "gn" 'helm-gtags-go-forward
+      "gp" 'helm-gtags-go-backward
       "gr" 'helm-gtags-find-rtag
       "gR" 'helm-gtags-resume
       "gs" 'helm-gtags-select


### PR DESCRIPTION
[#10031] counsle-gtags command doesn't work in c-c++ layer

Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3